### PR TITLE
Rebrand site for Let's Sprinkle AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LetsAI Studio Marketing Site
+# Let’s Sprinkle AI Marketing Site
 
-Modern marketing site for the LetsAI Studio agentic AI product team. Built with Next.js 15 App Router, React 19.1, Tailwind CSS v4, and Turbopack.
+Modern marketing site for Let’s Sprinkle AI, a customer experience AI studio based in Salt Lake City, Kolkata. Built with Next.js 15 App Router, React 19.1, Tailwind CSS v4, and Turbopack.
 
 ## Getting started
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,63 +4,68 @@ import "@/styles/globals.css";
 import { Analytics } from "@/lib/analytics";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://letsai.dev"),
+  metadataBase: new URL("https://letsprinkleai.com"),
   title: {
-    default: "LetsAI Studio — Agentic AI, built for production",
-    template: "%s | LetsAI Studio",
+    default: "Let’s Sprinkle AI — Customer experience copilots & automation",
+    template: "%s | Let’s Sprinkle AI",
   },
   description:
-    "Full-stack agentic AI product studio delivering LangGraph orchestration, OpenAI Agents, RAG copilots, and scalable inference.",
+    "Let’s Sprinkle AI designs customer experience copilots, analytics, and automation agents from our studio in Salt Lake City, Kolkata.",
   openGraph: {
-    title: "LetsAI Studio",
+    title: "Let’s Sprinkle AI",
     description:
-      "We design, ship, and scale AI assistants, multi-agent workflows, and RAG copilots—securely integrated with your stack.",
-    url: "https://letsai.dev",
-    siteName: "LetsAI Studio",
+      "Sprinkling intelligence across sales, support, and marketing with bespoke copilots, trusted guardrails, and on-call experts in India.",
+    url: "https://letsprinkleai.com",
+    siteName: "Let’s Sprinkle AI",
     locale: "en_US",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "LetsAI Studio",
+    title: "Let’s Sprinkle AI",
     description:
-      "Agentic AI development with LangGraph, CrewAI, MCP, and high-throughput inference.",
+      "AI strategy, design, and deployment for customer experience teams based in Kolkata, India.",
   },
   keywords: [
-    "Agentic AI",
-    "LangGraph",
-    "CrewAI",
-    "MCP",
-    "A2A",
-    "OpenAI Agents",
-    "RAG",
-    "LLMOps",
-    "vLLM",
-    "AWS Bedrock",
+    "Let’s Sprinkle AI",
+    "Customer experience AI",
+    "AI copilots",
+    "Automation agents",
+    "Kolkata AI studio",
+    "Indian AI company",
+    "LinkedIn Let’s Sprinkle AI",
+    "AI strategy",
+    "RAG copilots",
+    "AI automation",
   ],
 };
 
 const organizationSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
-  name: "LetsAI Studio",
-  url: "https://letsai.dev",
-  sameAs: [
-    "https://www.linkedin.com/company/letsai-studio",
-    "https://github.com/letsai-studio",
-  ],
+  name: "Let’s Sprinkle AI",
+  url: "https://letsprinkleai.com",
+  sameAs: ["https://www.linkedin.com/company/let-sprinkle-ai/"],
   description:
-    "Agentic AI product studio delivering LangChain, LangGraph, CrewAI, MCP, and OpenAI Agents integrations.",
-  logo: "https://letsai.dev/og-image.png",
+    "Let’s Sprinkle AI is a Kolkata-based studio crafting customer experience copilots, conversational analytics, and automation agents.",
+  logo: "https://letsprinkleai.com/assets/brand/lets-sprinkle-ai-logo.svg",
   contactPoint: [
     {
       "@type": "ContactPoint",
       contactType: "sales",
-      email: "hello@letsai.dev",
-      areaServed: "Global",
+      email: "contact@letsprinkleai.com",
+      telephone: "+91-79803-14116",
+      areaServed: "IN",
       availableLanguage: ["English"],
     },
   ],
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Salt Lake City",
+    addressRegion: "West Bengal",
+    postalCode: "700091",
+    addressCountry: "IN",
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/components/nav/Header.tsx
+++ b/components/nav/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { Menu } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -41,8 +42,20 @@ export function Header() {
       }`}
     >
       <Container className="flex h-20 items-center justify-between">
-        <Link href="#home" className="text-sm font-semibold uppercase tracking-[0.4em] text-[color:var(--accent)]">
-          LetsAI Studio
+        <Link
+          href="#home"
+          className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.4em] text-[color:var(--accent)]"
+          aria-label="Let's Sprinkle AI home"
+        >
+          <Image
+            src="/assets/brand/lets-sprinkle-ai-logo.svg"
+            alt="Let's Sprinkle AI logo"
+            width={120}
+            height={60}
+            className="h-10 w-auto drop-shadow-[0_0_20px_rgba(255,255,255,0.35)]"
+            priority
+          />
+          <span className="sr-only">Let’s Sprinkle AI</span>
         </Link>
         <nav className="hidden items-center gap-8 text-sm font-medium md:flex">
           {items.map((item) => (

--- a/components/nav/MobileMenu.tsx
+++ b/components/nav/MobileMenu.tsx
@@ -43,7 +43,7 @@ export function MobileMenu({ items, open, onClose }: MobileMenuProps) {
     >
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold uppercase tracking-[0.4em] text-[color:var(--accent)]">
-          LetsAI Studio
+          Let’s Sprinkle AI
         </span>
         <Button
           ref={closeRef}
@@ -68,7 +68,7 @@ export function MobileMenu({ items, open, onClose }: MobileMenuProps) {
         ))}
       </nav>
       <p className="mt-6 text-sm text-muted">
-        SOC 2 ready · Region-specific deployments · No training on your data.
+        Human-centered AI copilots · Enterprise guardrails · On-call support from Kolkata.
       </p>
     </div>
   );

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -20,15 +20,16 @@ export function Contact() {
     <Section id="contact" className="bg-[color:rgba(10,12,16,0.85)]">
       <Container className="grid gap-12 lg:grid-cols-[1fr_0.9fr]">
         <FadeIn className="space-y-6">
-          <SectionHeading eyebrow="Contact" label="Let’s scope your next agent" />
+          <SectionHeading eyebrow="Contact" label="Let’s start sprinkling intelligence" />
           <p className="text-base text-muted">
-            Share a bit about your product goals, models of interest, and success metrics. We respond within one business day
-            with a tailored roadmap and investment range.
+            Tell us about the customer journeys you want to elevate and the workflows you need to automate. We’ll respond within
+            one business day with next steps from a Let’s Sprinkle AI specialist.
           </p>
           <ul className="space-y-3 text-sm text-muted">
-            <li>✦ Email: <Link href="mailto:hello@letsai.dev">hello@letsai.dev</Link></li>
-            <li>✦ HQ: Remote-first with pods in NYC · London · Singapore</li>
-            <li>✦ Secure by design: SOC 2 aligned, ISO 27001 partners, SSO &amp; RBAC out of the box.</li>
+            <li>✦ Email: <Link href="mailto:contact@letsprinkleai.com">contact@letsprinkleai.com</Link></li>
+            <li>✦ Phone / WhatsApp: <Link href="tel:+917980314116">+91 79803 14116</Link></li>
+            <li>✦ LinkedIn: <Link href="https://www.linkedin.com/company/let-sprinkle-ai/" target="_blank" rel="noreferrer">Let’s Sprinkle AI</Link></li>
+            <li>✦ Studio: Sector V, Salt Lake City, Kolkata, India</li>
           </ul>
         </FadeIn>
         <FadeIn delay={0.1}>

--- a/components/sections/Footer.tsx
+++ b/components/sections/Footer.tsx
@@ -13,9 +13,9 @@ const footerLinks = [
 ];
 
 const socialLinks = [
-  { label: "LinkedIn", href: "https://www.linkedin.com/company/letsai-studio" },
-  { label: "GitHub", href: "https://github.com/letsai-studio" },
-  { label: "X", href: "https://x.com/letsai_studio" },
+  { label: "LinkedIn", href: "https://www.linkedin.com/company/let-sprinkle-ai/" },
+  { label: "Email", href: "mailto:contact@letsprinkleai.com" },
+  { label: "Call", href: "tel:+917980314116" },
 ];
 
 export function Footer() {
@@ -23,11 +23,13 @@ export function Footer() {
     <footer className="border-t border-[color:rgba(255,255,255,0.08)] bg-[color:rgba(5,6,9,0.9)] py-12">
       <Container className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
         <div className="space-y-3">
-          <p className="text-sm font-semibold uppercase tracking-[0.4em] text-[color:var(--accent)]">LetsAI Studio</p>
+          <p className="text-sm font-semibold uppercase tracking-[0.4em] text-[color:var(--accent)]">Let’s Sprinkle AI</p>
           <p className="max-w-md text-xs text-muted">
-            Full-stack agentic AI studio crafting LangGraph, CrewAI, MCP, and LLMOps foundations for production-grade products.
+            Applied AI studio building delightful copilots, automation agents, and analytics that help brands sprinkle intelligence
+            across customer journeys.
           </p>
-          <p className="text-xs text-muted">© {new Date().getFullYear()} LetsAI Studio. All rights reserved.</p>
+          <p className="text-xs text-muted">Salt Lake City · Kolkata, India · +91 79803 14116</p>
+          <p className="text-xs text-muted">© {new Date().getFullYear()} Let’s Sprinkle AI. All rights reserved.</p>
         </div>
         <div className="flex flex-1 flex-col gap-6 md:flex-row md:justify-end">
           <nav className="flex flex-wrap gap-4 text-xs text-muted">
@@ -38,11 +40,20 @@ export function Footer() {
             ))}
           </nav>
           <nav className="flex gap-4 text-xs text-muted">
-            {socialLinks.map((link) => (
-              <Link key={link.href} href={link.href} target="_blank" rel="noreferrer" className="transition hover:text-[color:var(--accent)]">
-                {link.label}
-              </Link>
-            ))}
+            {socialLinks.map((link) => {
+              const isExternal = link.href.startsWith("http");
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  target={isExternal ? "_blank" : undefined}
+                  rel={isExternal ? "noreferrer" : undefined}
+                  className="transition hover:text-[color:var(--accent)]"
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
           </nav>
         </div>
       </Container>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -19,19 +19,26 @@ export function Hero() {
     <Section id="home" className="overflow-hidden pb-20 pt-28 sm:pt-32">
       <Container className="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
         <FadeIn className="space-y-8">
-          <p className="text-xs uppercase tracking-[0.4em] text-[color:var(--accent)]">
-            Agentic product studio
-          </p>
+          <Image
+            src="/assets/brand/lets-sprinkle-ai-logo.svg"
+            alt="Let's Sprinkle AI logo"
+            width={200}
+            height={120}
+            className="h-16 w-auto drop-shadow-[0_0_50px_rgba(255,255,255,0.25)] sm:h-20"
+            priority
+          />
+          <p className="text-xs uppercase tracking-[0.4em] text-[color:var(--accent)]">Customer experience AI studio</p>
           <h1 className="text-balance text-4xl font-semibold leading-tight sm:text-6xl">
-            Agentic AI, built for production.
+            Sprinkle intelligence across every interaction.
           </h1>
           <p className="max-w-xl text-lg text-muted">
-            We design, ship, and scale AI assistants, multi-agent workflows, and RAG copilots—securely
-            integrated with your stack. Every deployment is evaluation-driven, compliant, and observability-first.
+            Let’s Sprinkle AI crafts copilots, multi-agent automation, and analytics layers that delight your customers while
+            respecting enterprise guardrails. From ideation to launch, we pair Kolkata-based builders with global best
+            practices.
           </p>
           <div className="flex flex-wrap items-center gap-4">
             <Link href="#contact" className={buttonVariants("primary")}>
-              Book a discovery call
+              Schedule a strategy call
             </Link>
             <Link href="#demos" className={buttonVariants("ghost", "gap-1")}>See live AI demo</Link>
           </div>

--- a/lib/ai/vercel-ai.ts
+++ b/lib/ai/vercel-ai.ts
@@ -9,10 +9,10 @@ const encoder = new TextEncoder();
 
 function createChunks(prompt: string) {
   return [
-    "Thanks for exploring the LetsAI chat sandbox. ",
-    "In production we route through the Vercel AI SDK's `streamText` helper or plug in OpenAI / Bedrock models. ",
+    "Thanks for exploring the Let’s Sprinkle AI sandbox. ",
+    "In production we weave in the Vercel AI SDK’s `streamText` helper alongside OpenAI, Bedrock, or custom models. ",
     "Because no provider key is configured we are streaming from a mock orchestrator instead. ",
-    `You asked: "${prompt}" — we'd orchestrate retrieval, evaluation, and guardrails before returning the final answer.`,
+    `You asked: "${prompt}" — we’d orchestrate retrieval, evaluation, and guardrails before returning the final answer.`,
   ];
 }
 

--- a/lib/analytics.tsx
+++ b/lib/analytics.tsx
@@ -8,7 +8,7 @@ export function Analytics() {
   return (
     <script
       defer
-      data-domain="letsai.dev"
+      data-domain="letsprinkleai.com"
       data-api="/analytics/event"
       src={`https://plausible.io/js/script.js?id=${id}`}
     />

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -19,6 +19,6 @@ export async function handleContactSubmission(payload: ContactPayload): Promise<
 
   return {
     success: true,
-    message: "Thanks! A specialist will be in touch within one business day.",
+    message: "Thanks! A Let’s Sprinkle AI specialist will be in touch within one business day.",
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "letsaimain",
+  "name": "lets-sprinkle-ai-site",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "letsaimain",
+      "name": "lets-sprinkle-ai-site",
       "version": "0.1.0",
       "dependencies": {
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "letsaimain",
+  "name": "lets-sprinkle-ai-site",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/public/assets/brand/lets-sprinkle-ai-logo.svg
+++ b/public/assets/brand/lets-sprinkle-ai-logo.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="320" viewBox="0 0 640 320">
+  <defs>
+    <radialGradient id="halo" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="55%" stop-color="#ffffff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="8" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <linearGradient id="strokeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#e6f7ff" stop-opacity="0.75" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="320" fill="url(#halo)" opacity="0.55" />
+  <g filter="url(#glow)" fill="none" stroke="url(#strokeGradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M88 206c26-54 26-120 0-120h-8" />
+    <path d="M58 204h70" />
+    <path d="M142 120c18 0 28 8 28 28 0 28-26 32-26 56 0 6 2 10 4 14" />
+    <path d="M170 120c-8 6-18 14-18 26 0 18 26 24 26 46 0 8-4 16-8 20" />
+    <path d="M200 168h32" />
+    <path d="M196 136c12 0 32 2 32 30 0 34-24 46-36 46-6 0-12-2-18-6" />
+    <path d="M260 120c-14 8-22 22-22 42 0 28 14 46 40 46 14 0 28-8 36-20" />
+    <path d="M332 120c-12 18-18 40-18 62 0 30 12 46 36 46 20 0 32-12 32-30 0-18-10-28-34-28-10 0-18 2-24 6" />
+    <path d="M332 200c12 14 28 22 50 22 36 0 64-20 86-54" />
+    <path d="M468 134c-24 38-36 80-36 122 0 30 12 42 28 42 18 0 34-18 46-40" />
+    <path d="M446 224c18 12 38 18 60 18 26 0 50-8 78-30" />
+    <path d="M508 166c20-14 36-36 46-66" />
+  </g>
+  <g filter="url(#glow)" fill="#ffffff" stroke="none">
+    <path d="M478 76l12 32 34 2-28 20 10 32-28-18-30 20 10-34-26-18 34-4z" opacity="0.95" />
+    <path d="M550 130l8 20 22 2-18 14 6 22-20-12-20 12 6-22-18-14 22-2z" opacity="0.85" />
+    <path d="M580 58l6 16 18 2-14 10 4 18-14-10-16 10 6-18-14-10 18-2z" opacity="0.75" />
+  </g>
+  <text x="64" y="126" fill="#ffffff" font-family="'Poiret One','Trebuchet MS',sans-serif" font-size="96" letter-spacing="3" filter="url(#glow)">Let’s</text>
+  <text x="232" y="244" fill="#ffffff" font-family="'Great Vibes','Brush Script MT',cursive" font-size="200" filter="url(#glow)">A</text>
+</svg>


### PR DESCRIPTION
## Summary
- Rebrand the marketing experience to Let’s Sprinkle AI, updating metadata, organization schema, and analytics configuration
- Refresh hero, navigation, contact, and footer sections with new branding, copy, and contact details
- Add the Let’s Sprinkle AI logo asset and update package metadata to reflect the new company name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1acb380008333a0d8d2710ccff5d7